### PR TITLE
Remove already quantized files from list

### DIFF
--- a/vall_e/emb/qnt.py
+++ b/vall_e/emb/qnt.py
@@ -90,11 +90,8 @@ def main():
 
     for path in tqdm(paths):
         out_path = _replace_file_extension(path, ".qnt.pt")
-        if out_path.exists():
-            continue
         qnt = encode_from_file(path)
         torch.save(qnt.cpu(), out_path)
-        del qnt
 
 if __name__ == "__main__":
     main()

--- a/vall_e/emb/qnt.py
+++ b/vall_e/emb/qnt.py
@@ -83,13 +83,18 @@ def main():
     paths = [*args.folder.rglob(f"*{args.suffix}")]
     random.shuffle(paths)
 
+    for idx, path in tqdm(enumerate(paths)):
+        out_path = _replace_file_extension(path, ".qnt.pt")
+        if out_path.exists():
+            paths.pop(idx)
+
     for path in tqdm(paths):
         out_path = _replace_file_extension(path, ".qnt.pt")
         if out_path.exists():
             continue
         qnt = encode_from_file(path)
         torch.save(qnt.cpu(), out_path)
-
+        del qnt
 
 if __name__ == "__main__":
     main()

--- a/vall_e/train.py
+++ b/vall_e/train.py
@@ -125,5 +125,4 @@ def main():
 
 
 if __name__ == "__main__":
-    torch.multiprocessing.set_start_method("spawn")
     main()

--- a/vall_e/train.py
+++ b/vall_e/train.py
@@ -125,4 +125,5 @@ def main():
 
 
 if __name__ == "__main__":
+    torch.multiprocessing.set_start_method("spawn")
     main()


### PR DESCRIPTION
Quick and simple tweak, removes quantized files from the path list, as its ever so slightly faster than re-iterating over them. Has the added bonus of adjusting the TQDM bar to the total needing to be quantized when resuming quantization